### PR TITLE
mikro ödeme alanadları değişikliği

### DIFF
--- a/lib/MikroOdeme/Common/SaleResourceModel.php
+++ b/lib/MikroOdeme/Common/SaleResourceModel.php
@@ -19,7 +19,7 @@ class SaleResourceModel extends BaseResourceModel
 {
 
     public function __construct(){
-        self::$wsdlAddress = "https://www.3pay.com/services/saleservice.asmx?wsdl";
+        self::$wsdlAddress = "https://www.wirecard.com.tr/services/saleservice.asmx?wsdl";
     }
 
 }

--- a/lib/MikroOdeme/Common/SmsResourceModel.php
+++ b/lib/MikroOdeme/Common/SmsResourceModel.php
@@ -22,11 +22,11 @@ class SmsResourceModel extends BaseResourceModel
 
     public function __construct($custom = null){
 
-        self::$wsdlAddress = "http://vas.mikro-odeme.com/services/msendsmsservice.asmx?wsdl";
+        self::$wsdlAddress = "http://www.wirecard.com.tr/vas/services/msendsmsservice.asmx?wsdl";
 
         //this means, custom number will be used
         if(!is_null($custom)){
-            self::$wsdlAddress = "http://vas.mikro-odeme.com/services/MCustomSendSMSService.asmx?wsdl";
+            self::$wsdlAddress = "http://www.wirecard.com.tr/vas/services/MCustomSendSMSService.asmx?wsdl";
         }
 
     }

--- a/lib/MikroOdeme/Common/SubscribeResourceModel.php
+++ b/lib/MikroOdeme/Common/SubscribeResourceModel.php
@@ -19,7 +19,7 @@ class SubscribeResourceModel extends BaseResourceModel
 {
 
     public function __construct(){
-        self::$wsdlAddress = "https://www.3pay.com/services/SubscriberManagementService.asmx?wsdl";
+        self::$wsdlAddress = "https://www.wirecard.com.tr/services/SubscriberManagementService.asmx?wsdl";
     }
 
     public function setSubscriberId($subscriberId){


### PR DESCRIPTION
Merhabalar aşşağıdaki şekilde bi bir mail aldım.
yapılan değişiklikler test edildi 


Değerli Üye İşyerimiz,

Wirecard Türkiye olarak kullanmaya başladığımız yeni alan adı ile ilgili yapılacak son düzenlemeler çerçevesinde bağlandığınız servis adreslerindeki, kullandığınız ürünlerdeki alan adlarını aşağıdaki şekilde güncellemenizi rica ederiz.

www.3pay.com -> www.wirecard.com.tr
www.mikro-odeme.com -> www.wirecard.com.tr
vas.mikro-odeme.com -> www.wirecard.com.tr/vas

5 Temmuz 2017 tarihinden itibaren eski alan adları kullanıma kapatılacaktır. Güncelleme planlarınızı bu doğrulta yapmanızı rica ederiz.

Sorularınız için integration@3pay.com adresi

İyi Çalışmalar

Wirecard
